### PR TITLE
nix: add lwt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,7 @@
       let
         pkgs = nixpkgs.legacyPackages."${system}";
         inherit (pkgs.ocamlPackages) buildDunePackage;
-      in
-      rec {
+      in rec {
         packages = rec {
           default = notty;
           notty = buildDunePackage {
@@ -19,7 +18,7 @@
             src = ./.;
             duneVersion = "3";
             nativeBuildInputs = with pkgs.ocamlPackages; [ cppo ];
-            propagatedBuildInputs = with pkgs.ocamlPackages; [ uutf ];
+            propagatedBuildInputs = with pkgs.ocamlPackages; [ uutf lwt ];
             doCheck = true;
           };
         };


### PR DESCRIPTION
We don't need lwt when building notty, but it is required when building the tests. The tests are useful to check how things look.