### PR TITLE
add support of dim/faint

### DIFF
--- a/examples/colors.ml
+++ b/examples/colors.ml
@@ -27,15 +27,18 @@ let colors = A.[
 ]
 
 let styles = A.[
-  "empty"      , empty
-; "bold"       , st bold
-; "italic"     , st italic
-; "underline"  , st underline
-; "blink"      , st blink
-; "reverse"    , st reverse
-; "bold/italic", st bold ++ st italic
-; "rev/underln", st underline ++ st reverse
-; "bold/rev"   , st reverse ++ st bold
+  "empty"       , empty
+; "bold"        , st bold
+; "faint"       , st faint
+; "italic"      , st italic
+; "underline"   , st underline
+; "blink"       , st blink
+; "reverse"     , st reverse
+; "bold/italic" , st bold ++ st italic
+; "faint/italic", st faint ++ st italic
+; "rev/underln" , st underline ++ st reverse
+; "bold/rev"    , st reverse ++ st bold
+; "faint/rev"   , st reverse ++ st faint
 ]
 
 let image w =

--- a/src/notty.ml
+++ b/src/notty.ml
@@ -209,11 +209,12 @@ module A = struct
   and b x = x land 0xff
 
   let bold      = 1
-  and italic    = 2
-  and dim       = 3
-  and underline = 4
-  and blink     = 8
-  and reverse   = 16
+  and dim       = 2
+  and faint     = 2
+  and italic    = 4
+  and underline = 8
+  and blink     = 16
+  and reverse   = 32
 
   let empty = { fg = 0; bg = 0; st = 0 }
 
@@ -511,7 +512,7 @@ module Cap = struct
 
   let ((<|), (<.), (<!)) = Buffer.(add_string, add_char, add_decimal)
 
-  let sts = [ ";1"; ";3"; ";4"; ";5"; ";7" ]
+  let sts = [ ";1"; ";2"; ";3"; ";4"; ";5"; ";7" ]
 
   let sgr { A.fg; bg; st } buf =
     buf <| "\x1b[0";

--- a/src/notty.mli
+++ b/src/notty.mli
@@ -138,8 +138,9 @@ module A : sig
   (** Additional text properties. *)
 
   val bold      : style
-  val italic    : style
   val dim       : style
+  val faint     : style
+  val italic    : style
   val underline : style
   val blink     : style
   val reverse   : style


### PR DESCRIPTION
This patch was cherry-picked from @favonia.

The dim style from before was introduced by me and is incorrect. This patch fixes that and also included a fix for some other styles.

![image](https://github.com/ocaml-dune/notty/assets/8614547/1cc104a2-34f7-4c49-a909-6ac1fea101de)
