### PR TITLE
Add mouse movement event

### DIFF
--- a/src/notty.ml
+++ b/src/notty.ml
@@ -549,8 +549,8 @@ module Cap = struct
     ; cr      = (fun b -> b <| "\x1b[1G")
     ; clreol  = (fun b -> b <| "\x1b[K")
     ; cursvis = (fun x b -> b <| if x then "\x1b[34h\x1b[?25h" else "\x1b[?25l")
-    ; mouse   = (fun x b -> b <| if x then "\x1b[?1000;1002;1005;1015;1006h"
-                                      else "\x1b[?1000;1002;1005;1015;1006l")
+    ; mouse   = (fun x b -> b <| if x then "\x1b[?1000;1003;1005;1015;1006h"
+                                      else "\x1b[?1000;1003;1005;1015;1006l")
     ; bpaste  = (fun x b -> b <| if x then "\x1b[?2004h" else "\x1b[?2004l")
     ; sgr }
 
@@ -640,7 +640,7 @@ module Unescape = struct
 
   type key = [ special | `Uchar of Uchar.t  | `ASCII of char ] * mods
 
-  type mouse = [ `Press of button | `Drag | `Release ] * (int * int) * mods
+  type mouse = [ `Press of button | `Drag | `Release | `Move ] * (int * int) * mods
 
   type paste = [ `Start | `End ]
 
@@ -792,7 +792,7 @@ module Unescape = struct
           | ('M', (#button as b), false) -> Some (`Press b)
           | ('M', #button, true)         -> Some `Drag
           | ('m', #button, false)        -> Some `Release
-          (* | ('M', `ALL   , true)         -> Some `Move *)
+          | ('M', `ALL   , true)         -> Some `Move
           | _                            -> None
         ) >>| fun e -> `Mouse (e, (x - 1, y - 1), mods)
 
@@ -803,7 +803,7 @@ module Unescape = struct
           | (#button as b, false) -> Some (`Press b)
           | (#button     , true ) -> Some `Drag
           | (`ALL        , false) -> Some `Release
-          (* | (`ALL        , true)  -> Some `Move *)
+          | (`ALL        , true)  -> Some `Move
           | _                     -> None
         ) >>| fun e -> `Mouse (e, (x - 1, y - 1), mods)
 

--- a/src/notty.mli
+++ b/src/notty.mli
@@ -473,7 +473,7 @@ module Unescape : sig
   type key = [ special | `Uchar of Uchar.t | `ASCII of char ] * mods
   (** Keypress event. *)
 
-  type mouse = [ `Press of button | `Drag | `Release ] * (int * int) * mods
+  type mouse = [ `Press of button | `Drag | `Release | `Move ] * (int * int) * mods
   (** Mouse event. *)
 
   type paste = [ `Start | `End ]


### PR DESCRIPTION
This is a useful feature that was added in https://github.com/pqwy/notty/pull/46. We can use this in the upcoming jobs tab PR to have more reactive visuals to the users mouse movement. I'm thinking tabs that highlight when the user hovers over them to indicate they are clickable.

This is something I've discussed before:
- https://github.com/ocaml/dune/issues/8620

Here is a demo where the application tracks the mouse and draws two lines.

[Screencast from 2023-10-17 18-31-30.webm](https://github.com/ocaml-dune/notty/assets/8614547/3143c54f-5998-41c6-9b30-39e295d5dc19)
