### PR TITLE
feat: detect horizontal mouse scrolling

### DIFF
--- a/src/notty.ml
+++ b/src/notty.ml
@@ -641,7 +641,7 @@ module Unescape = struct
   | `Function of int
   ]
 
-  type button = [ `Left | `Middle | `Right | `Scroll of [ `Up | `Down ] ]
+  type button = [ `Left | `Middle | `Right | `Scroll of [ `Up | `Down | `Left | `Right ] ]
 
   type mods = [ `Meta | `Ctrl | `Shift ] list
 
@@ -725,9 +725,9 @@ module Unescape = struct
       | 0              -> `Left
       | 1 when bit 6 p -> `Scroll `Down
       | 1              -> `Middle
-      | 2 when bit 6 p -> `ALL (* `Scroll `Left *)
+      | 2 when bit 6 p -> `Scroll `Left
       | 2              -> `Right
-      | 3 when bit 6 p -> `ALL (* `Scroll `Right *)
+      | 3 when bit 6 p -> `Scroll `Right
       | _              -> `ALL
     and drag = bit 5 p
     and mods =

--- a/src/notty.mli
+++ b/src/notty.mli
@@ -464,7 +464,7 @@ module Unescape : sig
   ]
   (** A selection of extra keys on the keyboard. *)
 
-  type button = [ `Left | `Middle | `Right | `Scroll of [ `Up | `Down ] ]
+  type button = [ `Left | `Middle | `Right | `Scroll of [ `Up | `Down | `Left | `Right ] ]
   (** Mouse buttons. *)
 
   type mods = [ `Meta | `Ctrl | `Shift ] list
@@ -510,7 +510,8 @@ module Unescape : sig
 
          {b Note} Every [`Press (`Left|`Middle|`Right)] generates a corresponding
          [`Release], but there is no portable way to detect which button was
-         released. [`Scroll (`Up|`Down)] presses are not followed by releases.
+         released. [`Scroll (`Up|`Down|`Left|`Right)] presses are not followed
+         by releases.
 
          }
       {- [`Paste (`Start|`End)] are {e bracketed paste} events, signalling the


### PR DESCRIPTION
This patch adds support for horizontal scroll detection. It is used in https://github.com/ocaml/dune/pull/12386.